### PR TITLE
rework VCO tuning

### DIFF
--- a/src/LMS7002M_vco.c
+++ b/src/LMS7002M_vco.c
@@ -14,6 +14,7 @@
 #include "LMS7002M_vco.h"
 #include <LMS7002M/LMS7002M_logger.h>
 #include <unistd.h>
+#include <string.h>
 
 static void LMS7002M_read_vco_cmp(LMS7002M_t *self, const int vco_cmp_addr)
 {
@@ -109,20 +110,25 @@ int LMS7002M_tune_vco(
     
     if (LMS7_get_log_level() >= LMS7_DEBUG){
 
+        char output[1024] = {'\0'};
         // Scan the comparators in the opposite direction to check for hyseresis
         scan_csw(self, -1, vco_csw_reg, csw_decending, vco_cmpho_reg, vco_cmplo_reg, vco_csw_addr, vco_cmp_addr);
 
-        printf("\nAscending:\n");
+        strcat(output, "Ascending comparator vals:\n");
         for (int i = 0; i < 256; i++)
         {
-            printf(" %i", csw_ascending[i]);
+            char* c = csw_ascending[i] == 0 ? "0" : csw_ascending[i] == 2 ? "2" : "3";
+            strcat(output+strlen(output), c);
         }
-        printf("\nDecending:\n");
+        LMS7_log(LMS7_DEBUG, output);
+        memset(output, '\0', sizeof(output));
+        strcat(output, "Decending comparator vals:\n");
         for (int i = 0; i < 256; i++)
         {
-            printf(" %i", csw_decending[i]);
+            char* c = csw_decending[i] == 0 ? "0" : csw_decending[i] == 2 ? "2" : "3";
+            strcat(output+strlen(output), c);
         }
-        printf("\n");
+        LMS7_log(LMS7_DEBUG, output);
     }
 
     int high_ct = 0;

--- a/src/LMS7002M_vco.c
+++ b/src/LMS7002M_vco.c
@@ -83,6 +83,16 @@ static int LMS7002M_tune_vco_sweep(
     return 0;
 }
 
+void scan_csw(LMS7002M_t *self, int dir, int *vco_csw_reg, int *csw_arr, int *vco_cmpho_reg, int *vco_cmplo_reg, const int vco_csw_addr, const int vco_cmp_addr){
+    int init = (dir > 0) ? 0 : 255;
+    for (int i = 0; i < 256; i++){
+        *vco_csw_reg = init + i*dir;
+        LMS7002M_regs_spi_write(self, vco_csw_addr);
+        LMS7002M_read_vco_cmp(self, vco_cmp_addr);
+        csw_arr[*vco_csw_reg] = *vco_cmplo_reg | *vco_cmpho_reg << 1;
+    }
+}
+
 int LMS7002M_tune_vco(
     LMS7002M_t *self,
     int *vco_csw_reg,
@@ -92,49 +102,62 @@ int LMS7002M_tune_vco(
     const int vco_cmp_addr
 )
 {
-    //check comparator under minimum setting
-    *vco_csw_reg = 0;
-    LMS7002M_regs_spi_write(self, vco_csw_addr);
-    LMS7002M_read_vco_cmp(self, vco_cmp_addr);
-    if (*vco_cmpho_reg == 1 && *vco_cmplo_reg == 1)
+    int csw_ascending[256];
+    int csw_decending[256];
+
+    scan_csw(self, 1, vco_csw_reg, csw_ascending, vco_cmpho_reg, vco_cmplo_reg, vco_csw_addr, vco_cmp_addr);
+    scan_csw(self, -1, vco_csw_reg, csw_decending, vco_cmpho_reg, vco_cmplo_reg, vco_csw_addr, vco_cmp_addr);
+
+
+    printf("\nAscending:\n");
+    for (int i = 0; i < 256; i++)
+    {
+        printf(" %i", csw_ascending[i]);
+    }
+    printf("\nDecending:\n");
+    for (int i = 0; i < 256; i++)
+    {
+        printf(" %i", csw_decending[i]);
+    }
+    printf("\n");
+
+    int high_ct = 0;
+    int low_ct = 0;
+    for (int i = 0; i < 256; i++) {
+        if (csw_ascending[i] == 3) high_ct++;
+        if (csw_ascending[i] == 0) low_ct++;
+    }
+    printf("high_ct=%i, low_ct=%i\n", high_ct, low_ct);
+
+
+    //LMS7_logf(LMS7_DEBUG, "CSW results: lo: %i %i, mid: %i %i, hi: %i %i",
+    //    csw_lo[0], csw_lo[1], csw_mid[0], csw_mid[1], csw_hi[0], csw_hi[1]);
+
+    if (high_ct == 256)
     {
         LMS7_log(LMS7_DEBUG, "VCO select FAIL - too high");
         return -1;
-    }
-
-    //check comparator under maximum setting
-    *vco_csw_reg = 255;
-    LMS7002M_regs_spi_write(self, vco_csw_addr);
-    LMS7002M_read_vco_cmp(self, vco_cmp_addr);
-    if (*vco_cmpho_reg == 0 && *vco_cmplo_reg == 0)
+    } else if (low_ct == 256)
     {
         LMS7_log(LMS7_DEBUG, "VCO select FAIL - too low");
         return -1;
     }
 
-    //search both segments of the 8-bit space
-    int lo0, hi0, lo1, hi1;
-    LMS7002M_tune_vco_sweep(self, vco_csw_reg, vco_csw_addr, vco_cmpho_reg, vco_cmplo_reg, vco_cmp_addr, 0, &lo0, &hi0);
-    LMS7002M_tune_vco_sweep(self, vco_csw_reg, vco_csw_addr, vco_cmpho_reg, vco_cmplo_reg, vco_cmp_addr, 128, &lo1, &hi1);
-
-    //determine overall high-low with overlap
-    int csw_lowest, csw_highest;
-    if (hi0 == lo1-1)
+    int csw_lowest = 0;
+    int csw_highest = 0;
+    /*
+    We need to find the boundary of the deadband range for the CSW register.
+    Though the samples may be noisy or have "stuck" values at the start,
+    so we try to be robust searching for a sequence like the following:
+    002222233
+    We in effect debounce the comparator a bit here.
+    */
+    for (int i = 0; i < 252; i++)
     {
-        csw_lowest = lo0;
-        csw_highest = hi1;
-    }
-
-    //otherwise use bigger range
-    else if ((hi0-lo0) > (hi1-lo1))
-    {
-        csw_lowest = lo0;
-        csw_highest = hi0;
-    }
-    else
-    {
-        csw_lowest = lo1;
-        csw_highest = hi1;
+        if (csw_ascending[i] == 0 && csw_ascending[i+1] == 0 && csw_ascending[i+2] == 2 && csw_ascending[i+3] == 2)
+            csw_lowest = i+2;
+        else if (csw_ascending[i] == 2 && csw_ascending[i+1] == 2 && csw_ascending[i+2] == 3 && csw_ascending[i+3] == 3)
+            csw_highest = i+1;
     }
 
     //set the midpoint of the search

--- a/src/LMS7002M_vco.c
+++ b/src/LMS7002M_vco.c
@@ -106,20 +106,24 @@ int LMS7002M_tune_vco(
     int csw_decending[256];
 
     scan_csw(self, 1, vco_csw_reg, csw_ascending, vco_cmpho_reg, vco_cmplo_reg, vco_csw_addr, vco_cmp_addr);
-    scan_csw(self, -1, vco_csw_reg, csw_decending, vco_cmpho_reg, vco_cmplo_reg, vco_csw_addr, vco_cmp_addr);
+    
+    if (LMS7_get_log_level() >= LMS7_DEBUG){
 
+        // Scan the comparators in the opposite direction to check for hyseresis
+        scan_csw(self, -1, vco_csw_reg, csw_decending, vco_cmpho_reg, vco_cmplo_reg, vco_csw_addr, vco_cmp_addr);
 
-    printf("\nAscending:\n");
-    for (int i = 0; i < 256; i++)
-    {
-        printf(" %i", csw_ascending[i]);
+        printf("\nAscending:\n");
+        for (int i = 0; i < 256; i++)
+        {
+            printf(" %i", csw_ascending[i]);
+        }
+        printf("\nDecending:\n");
+        for (int i = 0; i < 256; i++)
+        {
+            printf(" %i", csw_decending[i]);
+        }
+        printf("\n");
     }
-    printf("\nDecending:\n");
-    for (int i = 0; i < 256; i++)
-    {
-        printf(" %i", csw_decending[i]);
-    }
-    printf("\n");
 
     int high_ct = 0;
     int low_ct = 0;
@@ -127,11 +131,7 @@ int LMS7002M_tune_vco(
         if (csw_ascending[i] == 3) high_ct++;
         if (csw_ascending[i] == 0) low_ct++;
     }
-    printf("high_ct=%i, low_ct=%i\n", high_ct, low_ct);
-
-
-    //LMS7_logf(LMS7_DEBUG, "CSW results: lo: %i %i, mid: %i %i, hi: %i %i",
-    //    csw_lo[0], csw_lo[1], csw_mid[0], csw_mid[1], csw_hi[0], csw_hi[1]);
+    LMS7_logf(LMS7_DEBUG, "high_ct=%i, low_ct=%i\n", high_ct, low_ct);
 
     if (high_ct == 256)
     {


### PR DESCRIPTION
The current VCO tuning algorithm experiences periodic failures. We have isolated these to "stuck" comparator readings at the low and high end of the CSW range, while a valid solution exists inside the range. We change the algorithm to exhaustively search the space and debounce the reading to ensure we can always find a valid CSW value and avoid failure. Root cause of the "stuck" comparator is TBD.

cc @zsoerenm