### PR TITLE
reduce VCO comparator settling time to 100 microseconds

### DIFF
--- a/src/LMS7002M_vco.c
+++ b/src/LMS7002M_vco.c
@@ -23,7 +23,7 @@ static void LMS7002M_read_vco_cmp(LMS7002M_t *self, const int vco_cmp_addr)
     LMS7002M_regs_spi_read(self, vco_cmp_addr);
 
     //sleep while the comparator value settles
-    usleep(1000);
+    usleep(100);
 
     //final read of the comparator after settling
     LMS7002M_regs_spi_read(self, vco_cmp_addr);


### PR DESCRIPTION
Since we now exhaustively search the space, this is quite time consuming. The limesuite driver uses a 50 microsecond settling time: https://github.com/myriadrf/LimeSuite/blob/3a9d55e596515f204119ec52b25cab4de505d332/src/lms7002m/LMS7002M.cpp#L1255

100 microseconds is still double what the vendor uses, and significantly speeds up the VCO tuning.